### PR TITLE
exclude逻辑

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ const babelPresetMiniprogram = declare((api, opts, dirname) => {
         .getModulesListForTargetVersion(polyfillCoreJsVersion)
         .filter(
           (module) =>
-            !polyfillExcludeRegexps.some((exclude) => exclude.test(module))
+            polyfillExcludeRegexps.some((exclude) => exclude.test(module))
         )
     );
   }


### PR DESCRIPTION
我认为miniprogram-compat里面的polyfill应该是基础库已经处理过的,不需要再处理

官网原文:
> 关于polyfill，基础库中已经引入了大量的es6相关的 polyfill [可参考文档](https://developers.weixin.qq.com/miniprogram/dev/framework/runtime/js-support.html)，增强编译下，新增：Array.prototype.includes(es7)、Object.entries(es8)、Object.values(es8)